### PR TITLE
Removendo dados sensíveis do código e colocando como variáveis de ambiente

### DIFF
--- a/back/.env.example
+++ b/back/.env.example
@@ -1,0 +1,10 @@
+# Mailer
+
+MAILER_HOST=
+MAILER_PORT=
+MAILER_USER=
+MAILER_PASS=
+
+# Database
+
+MONGO_URL=

--- a/back/.gitignore
+++ b/back/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+
+.env

--- a/back/README.md
+++ b/back/README.md
@@ -1,0 +1,25 @@
+# Configuração do projeto
+
+**Instalar dependências**
+
+```
+yarn install
+ou
+npm install
+```
+
+**Configurar variáveis de ambiente**
+
+Criar um arquivo chamado `.env` na raiz do projeto `back`. O arquivo deve seguir o template presente no arquivo `.env.example` com os valores preenchidos.
+
+```
+cp .env.example .env
+```
+
+**Executando projeto**
+
+```
+yarn start
+ou
+npm start
+```

--- a/back/package.json
+++ b/back/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "date-fns": "^2.19.0",
+    "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "mongoose": "^5.12.2",
     "nodemailer": "^6.5.0"

--- a/back/src/database.js
+++ b/back/src/database.js
@@ -1,5 +1,5 @@
 const mongoose = require('mongoose')
-const mongooseConectUri = 'mongodb://localhost/querodelivery'
+const mongooseConectUri = process.env.MONGO_URL
 
 mongoose.connect(mongooseConectUri, {
   useNewUrlParser: true,

--- a/back/src/lib/mailer.js
+++ b/back/src/lib/mailer.js
@@ -1,10 +1,10 @@
 const nodemailer = require('nodemailer')
 
 module.exports = nodemailer.createTransport({
-    host: "smtp.mailtrap.io",
-    port: 2525,
+    host: process.env.MAILER_HOST,
+    port: process.env.MAILER_PORT,
     auth: {
-      user: "844f01d5213bd1",
-      pass: "fef1dea5e0637b"
+      user: process.env.MAILER_USER,
+      pass: process.env.MAILER_PASS
     }
 })

--- a/back/src/server.js
+++ b/back/src/server.js
@@ -1,3 +1,5 @@
+require('dotenv').config()
+
 const express = require('express')
 const routes = require ("./routes")
 require('./database')

--- a/back/yarn.lock
+++ b/back/yarn.lock
@@ -346,6 +346,11 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"


### PR DESCRIPTION
Alguns dados sensíveis, como dados para conexão com banco, autenticação com provedor de emails, não é tão seguro manter no código `hard-code`, pra esses casos é melhor deixa-los configurados como variáveis de ambiente, desse modo a aplicação se torna flexível dependendo de qual ambiente está rodando.

Modificações propostas:
- Criação do .gitignore para o projeto do backend
- Adição da biblioteca `dotenv` para carregar como variaveis de ambientes o arquivo .env
- Um arquivo .env.example para servir de template, de quais variaveis precisam ser configuradas
- README com instruções de como configurar o projeto